### PR TITLE
Add frontend React components

### DIFF
--- a/frontend/app/components/CategoryFilter.tsx
+++ b/frontend/app/components/CategoryFilter.tsx
@@ -1,0 +1,40 @@
+interface CategoryFilterProps {
+    categories: string[];
+    selectedCategory: string;
+    onCategoryChange: (category: string) => void;
+}
+
+export default function CategoryFilter({
+    categories,
+    selectedCategory,
+    onCategoryChange,
+}: CategoryFilterProps) {
+    return (
+        <div className="mb-6">
+            <h3 className="text-[#cdd6f4] font-semibold mb-3">Categories</h3>
+            <div className="flex flex-wrap gap-2">
+                <button
+                    onClick={() => onCategoryChange("all")}
+                    className={`px-3 py-1.5 rounded-full text-sm transition-colors ${selectedCategory === "all"
+                            ? "bg-[#cba6f7] text-[#1e1e2e]"
+                            : "bg-[#313244] text-[#a6adc8] hover:bg-[#45475a]"
+                        }`}
+                >
+                    All
+                </button>
+                {categories.map((category) => (
+                    <button
+                        key={category}
+                        onClick={() => onCategoryChange(category)}
+                        className={`px-3 py-1.5 rounded-full text-sm transition-colors ${selectedCategory === category
+                                ? "bg-[#cba6f7] text-[#1e1e2e]"
+                                : "bg-[#313244] text-[#a6adc8] hover:bg-[#45475a]"
+                            }`}
+                    >
+                        {category}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/components/CodeBlock.tsx
+++ b/frontend/app/components/CodeBlock.tsx
@@ -1,0 +1,40 @@
+interface CodeBlockProps {
+    code: string;
+    language: string;
+}
+
+export default function CodeBlock({ code, language }: CodeBlockProps) {
+    return (
+        <div className="relative bg-[#1e1e2e] border border-[#313244] rounded-lg overflow-hidden">
+            <div className="flex justify-between items-center py-2 px-4 bg-[#313244] border-b border-[#45475a]">
+                <div className="flex items-center">
+                    <span className="text-xs font-mono text-[#cba6f7]">
+                        {language === "csharp" ? "C#" : language}
+                    </span>
+                </div>
+                <div className="flex space-x-1">
+                    <div className="h-3 w-3 rounded-full bg-[#f38ba8]" />
+                    <div className="h-3 w-3 rounded-full bg-[#f9e2af]" />
+                    <div className="h-3 w-3 rounded-full bg-[#a6e3a1]" />
+                </div>
+            </div>
+            <pre className="p-4 overflow-x-auto">
+                <code className="text-sm font-mono text-[#cdd6f4] whitespace-pre">
+                    {code}
+                </code>
+            </pre>
+            <button
+                className="absolute top-2 right-14 text-[#a6adc8] hover:text-[#cdd6f4] p-1 rounded"
+                title="Copy code"
+                onClick={() => {
+                    navigator.clipboard.writeText(code);
+                    // You could add toast notification here
+                }}
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75" />
+                </svg>
+            </button>
+        </div>
+    );
+}

--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -1,0 +1,63 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export default function Footer() {
+    return (
+        <footer className="bg-[#11111b] py-12">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
+                    <div>
+                        <h3 className="text-lg font-semibold mb-4 text-[#cdd6f4]">Product</h3>
+                        <ul className="space-y-2">
+                            <li><Link href="/snippets" className="text-[#a6adc8] hover:text-[#b4befe] transition">Snippets</Link></li>
+                            <li><Link href="#pricing" className="text-[#a6adc8] hover:text-[#b4befe] transition">Pricing</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Changelog</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Roadmap</Link></li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 className="text-lg font-semibold mb-4 text-[#cdd6f4]">Resources</h3>
+                        <ul className="space-y-2">
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Documentation</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Tutorials</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Examples</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Blog</Link></li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 className="text-lg font-semibold mb-4 text-[#cdd6f4]">Company</h3>
+                        <ul className="space-y-2">
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">About</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Team</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Careers</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Contact</Link></li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 className="text-lg font-semibold mb-4 text-[#cdd6f4]">Legal</h3>
+                        <ul className="space-y-2">
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Privacy</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Terms</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">License</Link></li>
+                            <li><Link href="#" className="text-[#a6adc8] hover:text-[#b4befe] transition">Cookies</Link></li>
+                        </ul>
+                    </div>
+                </div>
+                <div className="mt-12 pt-8 border-t border-[#313244] flex flex-col md:flex-row justify-between items-center">
+                    <div className="flex items-center">
+                        <Image
+                            src="/logo.svg"
+                            alt="UnitySnippets Logo"
+                            width={130}
+                            height={28}
+                            className="invert"
+                        />
+                    </div>
+                    <div className="mt-4 md:mt-0 text-[#a6adc8] text-sm">
+                        © {new Date().getFullYear()} UnitySnippets. All rights reserved.
+                    </div>
+                </div>
+            </div>
+        </footer>
+    );
+}

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -1,0 +1,55 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export default function Header() {
+    return (
+        <header className="bg-[#1e1e2e] border-b border-[#313244] sticky top-0 z-50">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                <div className="flex justify-between items-center">
+                    <div className="flex items-center">
+                        <Link href="/" className="flex items-center">
+                            <Image
+                                src="/logo.svg"
+                                alt="UnitySnippets Logo"
+                                width={150}
+                                height={32}
+                                priority
+                                className="invert"
+                            />
+                        </Link>
+                    </div>
+                    <nav className="hidden md:flex space-x-8">
+                        <Link href="/snippets" className="text-[#a6adc8] hover:text-[#b4befe] transition duration-200">
+                            Snippets
+                        </Link>
+                        <Link href="#pricing" className="text-[#a6adc8] hover:text-[#b4befe] transition duration-200">
+                            Pricing
+                        </Link>
+                        <Link href="#docs" className="text-[#a6adc8] hover:text-[#b4befe] transition duration-200">
+                            Documentation
+                        </Link>
+                    </nav>
+                    <div className="hidden md:flex items-center space-x-4">
+                        <Link
+                            href="/login"
+                            className="text-[#a6adc8] hover:text-[#b4befe] transition duration-200"
+                        >
+                            Log in
+                        </Link>
+                        <Link
+                            href="/signup"
+                            className="bg-[#cba6f7] hover:bg-[#b4befe] text-[#1e1e2e] px-4 py-2 rounded-md transition duration-200"
+                        >
+                            Sign up
+                        </Link>
+                    </div>
+                    <button className="md:hidden text-[#a6adc8] hover:text-[#b4befe]">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </header>
+    );
+}

--- a/frontend/app/components/SearchBar.tsx
+++ b/frontend/app/components/SearchBar.tsx
@@ -1,0 +1,35 @@
+interface SearchBarProps {
+    searchQuery: string;
+    onSearchChange: (query: string) => void;
+}
+
+export default function SearchBar({ searchQuery, onSearchChange }: SearchBarProps) {
+    return (
+        <div className="relative mb-6">
+            <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                <svg
+                    className="w-4 h-4 text-[#a6adc8]"
+                    aria-hidden="true"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 20 20"
+                >
+                    <path
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"
+                    />
+                </svg>
+            </div>
+            <input
+                type="search"
+                value={searchQuery}
+                onChange={(e) => onSearchChange(e.target.value)}
+                className="block w-full p-3 pl-10 text-sm rounded-lg bg-[#313244] border border-[#45475a] placeholder-[#a6adc8] text-[#cdd6f4] focus:outline-none focus:border-[#cba6f7]"
+                placeholder="Search snippets..."
+            />
+        </div>
+    );
+}

--- a/frontend/app/components/SnippetCard.tsx
+++ b/frontend/app/components/SnippetCard.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+interface SnippetCardProps {
+    id: string;
+    title: string;
+    description: string;
+    category: string;
+    language: string;
+    createdAt: string;
+    likesCount: number;
+    downloadsCount: number;
+}
+
+export default function SnippetCard({
+    id,
+    title,
+    description,
+    category,
+    language,
+    createdAt,
+    likesCount,
+    downloadsCount,
+}: SnippetCardProps) {
+    // Format date
+    const formattedDate = new Date(createdAt).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    });
+
+    return (
+        <Link
+            href={`/snippets/${id}`}
+            className="block bg-[#313244] rounded-lg border border-[#45475a] hover:border-[#cba6f7] transition-colors p-5"
+        >
+            <div className="space-y-4">
+                <div className="flex justify-between items-start">
+                    <div>
+                        <span className="px-2 py-1 text-xs rounded-full bg-[#cba6f7]/20 text-[#cba6f7]">
+                            {category}
+                        </span>
+                        <span className="ml-2 px-2 py-1 text-xs rounded-full bg-[#89b4fa]/20 text-[#89b4fa]">
+                            {language}
+                        </span>
+                    </div>
+                </div>
+
+                <div>
+                    <h3 className="text-xl font-semibold text-[#cdd6f4]">{title}</h3>
+                    <p className="mt-2 text-[#a6adc8] line-clamp-2">{description}</p>
+                </div>
+
+                <div className="flex justify-between items-center text-sm text-[#a6adc8]">
+                    <div>{formattedDate}</div>
+                    <div className="flex space-x-4">
+                        <div className="flex items-center space-x-1">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+                            </svg>
+                            <span>{likesCount}</span>
+                        </div>
+                        <div className="flex items-center space-x-1">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                            </svg>
+                            <span>{downloadsCount}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Link>
+    );
+}


### PR DESCRIPTION
This PR adds the React components for the frontend of the UnitySnippets website:

1. Header.tsx - Navigation header component
2. Footer.tsx - Site footer with links and copyright
3. SearchBar.tsx - Search input for snippets
4. SnippetCard.tsx - Card component for displaying snippet previews
5. CategoryFilter.tsx - Filter component for snippet categories
6. CodeBlock.tsx - Component for displaying code with syntax highlighting

These components follow the Catppuccin Mocha color scheme and use TailwindCSS for styling.